### PR TITLE
CI: update default ALP target

### DIFF
--- a/github_templates/ci.yml.tmpl
+++ b/github_templates/ci.yml.tmpl
@@ -50,6 +50,6 @@ jobs:
     - uses: qiime2/action-library-packaging@alpha1
       with:
         package-name: %PACKAGE_NAME%
-        build-target: tested
+        build-target: dev
         additional-tests: %ADDITIONAL_TESTS%
         library-token: ${{ secrets.LIBRARY_TOKEN }}


### PR DESCRIPTION
@thermokarst, ran into this with q2-fmt. Worked out, since we probably want to target release in that particular repo for now, but it seems like this file should be use `dev` instead of `tested` these days, right?